### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      npm-development:
+        update-types:
+          - "minor"
+          - "patch"
+        dependency-type: "development"
+      npm-production:
+        update-types:
+          - "minor"
+          - "patch"
+        dependency-type: "production"


### PR DESCRIPTION
This PR adds the dependabot configuration file necessary for GitHub to automatically open PRs for out of date dependencies.

Dependency updates will be grouped by development/production types if they are minor/patch updates. Major version updates will have their own PRs since they may include breaking changes.